### PR TITLE
Best practices update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,13 @@
-FROM cern/cc7-base
-ADD . /cms-htcondor-es
-RUN yum install -y git python36-virtualenv
-RUN virtualenv-3 -p python3 /cms-htcondor-es/venv
-RUN source /cms-htcondor-es/venv/bin/activate && pip install -r /cms-htcondor-es/requirements.txt
-ENV PYTHONPATH=/cms-htcondor-es/venv/lib/python3.6/site-packages:/cms-htcondor-es/src
-ENTRYPOINT ["python3", "/cms-htcondor-es/spider_cms.py"]
-#CMD ["--help"]
+FROM cern/cc7-base:20190724
+COPY ./requirements.txt /cms-htcondor-es/requirements.txt
+RUN yum install -y git python36 python36-virtualenv python36-pip && \
+ln -fs /usr/bin/python3 /usr/bin/python && \
+ln -fs /usr/bin/pip3.6 /usr/bin/pip &&\
+pip install -r /cms-htcondor-es/requirements.txt
+COPY . /cms-htcondor-es
+RUN useradd --uid 1414 -ms /bin/bash spider &&\
+chown -R spider /cms-htcondor-es
+USER spider
+ENV PYTHONPATH "${PYTHONPATH}:/cms-htcondor-es/src"
+WORKDIR /cms-htcondor-es
+ENTRYPOINT ["/usr/bin/python", "/cms-htcondor-es/spider_cms.py"]


### PR DESCRIPTION
Use a specific image tag
Layer the build to reduce the number of layers and minimize the rebuilds on code change.
As the docker isolate the app, a virtualenv is not required. (no using a virtualenv will decrease the image size)
Use a non-root user